### PR TITLE
README: Correcting ORBit URL for downloading.

### DIFF
--- a/README
+++ b/README
@@ -48,7 +48,7 @@ dependencies should be compiled in the order they are listed here):
 
 	* ORBit 2.9.8 or later
 
-	     ftp://ftp.gnome.org/pub/gnome/sources/libsoup
+	     ftp://ftp.gnome.org/pub/gnome/sources/ORBit2/
 	
 	* libsoup 2.2.1 or later
 


### PR DESCRIPTION
The README accidentally had libsoup's URL for ORBit, confusing users where to download ORBit for installation.  Note: The libsoup URL for the libsoup reference (just below ORBit in the README) was not modified as it works just fine.
