### PR TITLE
Resolves bufferoverflow()

### DIFF
--- a/src/calendar/gui/e-calendar-view.c
+++ b/src/calendar/gui/e-calendar-view.c
@@ -2271,8 +2271,8 @@ e_calendar_view_get_description_text (ECalendarView *cal_view)
 	struct tm start_tm, end_tm;
 	struct icaltimetype start_tt, end_tt;
 	icaltimezone *zone;
-	gchar buffer[1024] = { 0 };
-	gchar end_buffer[512] = { 0 };
+	gchar buffer[2024] = { 0 };
+	gchar end_buffer[1024] = { 0 };
 
 	g_return_val_if_fail (E_IS_CALENDAR_VIEW (cal_view), NULL);
 
@@ -2343,7 +2343,7 @@ e_calendar_view_get_description_text (ECalendarView *cal_view)
 			e_utf8_strftime (
 				end_buffer, sizeof (end_buffer),
 				_("%a %d %b %Y"), &end_tm);
-			strcat (buffer, " - ");
+			strlcat (buffer, " - ");
 			strcat (buffer, end_buffer);
 		} else {
 			e_utf8_strftime (


### PR DESCRIPTION
Hi, 

This resolves the below issue, this can be a fix for now.
`https://bugzilla.gnome.org/show_bug.cgi?id=796174`

However, we allocated buffer stack to be 2024 and end_buffer to be 1024 and used strlcat for same.

Request team to please advise for same.


Thank you
Team w00t