### PR TITLE
add compiled date time to about panel

### DIFF
--- a/src/shell/e-shell-utils.c
+++ b/src/shell/e-shell-utils.c
@@ -347,7 +347,7 @@ e_shell_utils_run_help_about (EShell *shell)
 	gtk_show_about_dialog (
 		e_shell_get_active_window (shell),
 		"program-name", "Evolution",
-		"version", VERSION VERSION_SUBSTRING " " VERSION_COMMENT,
+		"version", VERSION VERSION_SUBSTRING " " VERSION_COMMENT " Compiled: " __DATE__ " " __TIME__,
 		"copyright", EVOLUTION_COPYRIGHT,
 		"comments", _("Groupware Suite"),
 		"website", PACKAGE_URL,


### PR DESCRIPTION
I find this useful to have when trying to determine how far out of date my running version of evolution has become